### PR TITLE
Add KEYS command

### DIFF
--- a/kedis/src/commonMain/kotlin/io/github/domgew/kedis/KedisClient.kt
+++ b/kedis/src/commonMain/kotlin/io/github/domgew/kedis/KedisClient.kt
@@ -9,6 +9,7 @@ import io.github.domgew.kedis.commands.KedisCommand
 import io.github.domgew.kedis.commands.KedisHashCommands
 import io.github.domgew.kedis.commands.KedisServerCommands
 import io.github.domgew.kedis.commands.KedisValueCommands
+import io.github.domgew.kedis.commands.KedisKeysCommands
 import io.github.domgew.kedis.impl.DefaultKedisClient
 import io.github.domgew.kedis.results.server.BgSaveResult
 import io.github.domgew.kedis.results.server.InfoSection
@@ -533,6 +534,29 @@ public interface KedisClient : AutoCloseable {
         execute(
             command = KedisValueCommands.exists(
                 key = key,
+            ),
+        )
+
+    /**
+     * @see [KedisKeysCommands.keys]
+     */
+    @Deprecated(
+        message = "Use commands",
+        replaceWith = ReplaceWith(
+            expression = "execute(\n" +
+                "    command = KedisKeysCommands.keys(\n" +
+                "        pattern = pattern,\n" +
+                "    ),\n" +
+                ")",
+            "io.github.domgew.kedis.commands.KedisKeysCommands",
+        ),
+    )
+    public suspend fun keys(
+        pattern: String,
+    ): List<String> =
+        execute(
+            command = KedisKeysCommands.keys(
+                pattern = pattern,
             ),
         )
 

--- a/kedis/src/commonMain/kotlin/io/github/domgew/kedis/commands/KedisKeysCommands.kt
+++ b/kedis/src/commonMain/kotlin/io/github/domgew/kedis/commands/KedisKeysCommands.kt
@@ -1,0 +1,19 @@
+package io.github.domgew.kedis.commands
+
+import io.github.domgew.kedis.commands.keys.KeysCommand
+
+public object KedisKeysCommands {
+
+    /**
+     * Returns the keys matching the given [pattern].
+     *
+     * [https://redis.io/commands/keys/](https://redis.io/commands/keys/)
+     * @return The keys matching [pattern]
+     */
+    public fun keys(
+        pattern: String,
+    ): KedisCommand<List<String>> =
+        KeysCommand(
+            pattern = pattern,
+        )
+}

--- a/kedis/src/commonMain/kotlin/io/github/domgew/kedis/commands/keys/KeysCommand.kt
+++ b/kedis/src/commonMain/kotlin/io/github/domgew/kedis/commands/keys/KeysCommand.kt
@@ -1,0 +1,46 @@
+package io.github.domgew.kedis.commands.keys
+
+import io.github.domgew.kedis.KedisException
+import io.github.domgew.kedis.commands.KedisFullCommand
+import io.github.domgew.kedis.impl.RedisMessage
+
+// see https://redis.io/commands/keys/
+internal class KeysCommand(
+    val pattern: String,
+) : KedisFullCommand<List<String>> {
+    override fun fromRedisResponse(response: RedisMessage): List<String> =
+        when (response) {
+            is RedisMessage.ArrayMessage ->
+                response.value.map { item ->
+                    if (item is RedisMessage.StringMessage) {
+                        item.value
+                    } else {
+                        throw KedisException.WrongResponseException(
+                            message = "Expected string item, was ${item::class.simpleName}",
+                        )
+                    }
+                }
+
+            is RedisMessage.ErrorMessage ->
+                handleRedisErrorResponse(
+                    response = response,
+                )
+
+            else ->
+                throw KedisException.WrongResponseException(
+                    message = "Expected array response, was ${response::class.simpleName}",
+                )
+        }
+
+    override fun toRedisRequest(): RedisMessage =
+        RedisMessage.ArrayMessage(
+            value = listOf(
+                RedisMessage.BulkStringMessage(OPERATION_NAME),
+                RedisMessage.BulkStringMessage(pattern),
+            ),
+        )
+
+    companion object {
+        private const val OPERATION_NAME = "KEYS"
+    }
+}

--- a/kedis/src/commonTest/kotlin/io/github/domgew/kedis/KeysE2eTest.kt
+++ b/kedis/src/commonTest/kotlin/io/github/domgew/kedis/KeysE2eTest.kt
@@ -1,0 +1,72 @@
+package io.github.domgew.kedis
+
+import io.github.domgew.kedis.arguments.server.SyncOption
+import io.github.domgew.kedis.commands.KedisKeysCommands
+import io.github.domgew.kedis.commands.KedisServerCommands
+import io.github.domgew.kedis.commands.KedisValueCommands
+import io.github.domgew.kedis.utils.TestConfigUtil
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
+
+class KeysE2eTest {
+
+    @Test
+    fun test() = runTest {
+        withContext(Dispatchers.Default) {
+            val key1 = "key1"
+            val key2 = "key2"
+            val value1 = "v1"
+            val value2 = "v2"
+
+            KedisClient.newClient(
+                KedisConfiguration(
+                    endpoint = KedisConfiguration.Endpoint.HostPort(
+                        host = "127.0.0.1",
+                        port = TestConfigUtil.getPort(),
+                    ),
+                    authentication = KedisConfiguration.Authentication.NoAutoAuth,
+                    connectionTimeout = 2.seconds,
+                ),
+            )
+                .use { client ->
+                    assertTrue(
+                        client.execute(
+                            command = KedisServerCommands.flushAll(
+                                sync = SyncOption.SYNC,
+                            ),
+                        ),
+                    )
+
+                    client.execute(
+                        command = KedisValueCommands.set(
+                            key = key1,
+                            value = value1,
+                        ),
+                    )
+                    client.execute(
+                        command = KedisValueCommands.set(
+                            key = key2,
+                            value = value2,
+                        ),
+                    )
+
+                    assertEquals(
+                        listOf(
+                            key1,
+                            key2,
+                        ),
+                        client.execute(
+                            command = KedisKeysCommands.keys(
+                                pattern = "key*",
+                            ),
+                        ),
+                    )
+                }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `KedisKeysCommands` with `keys()`
- implement `KeysCommand`
- expose convenience `keys` function on `KedisClient`
- test KEYS command

## Testing
- `./gradlew :kedis:smartTest` *(fails: Unable to download Kotlin native dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6850dc34683c8332af6fc4e9e38edd62